### PR TITLE
Add issue files for DB, auth/admin, and bulk mailer

### DIFF
--- a/.github/ISSUES/001-add-persistent-db.md
+++ b/.github/ISSUES/001-add-persistent-db.md
@@ -1,0 +1,17 @@
+# Add persistent database for activities & registrations
+
+**Labels:** enhancement, feature, backend
+**Priority:** Medium
+
+## Summary
+Replace the current in-memory `activities` store with a persistent database and add models + migrations.
+
+## Acceptance criteria
+- Add DB configuration with a sensible default (SQLite for local dev) and support for env var-based production DB.
+- Add SQLAlchemy models for `Activity` and `Registration` (with foreign keys and timestamps).
+- Add Alembic migrations (or equivalent) and update README with setup instructions.
+- Replace endpoints to use the DB for listing activities, signups and unregistrations.
+- Add unit tests covering CRUD and signup/unregister flows.
+
+## Notes
+This enables persistence and opens the path to other features (forms, CSV export, admin UI).

--- a/.github/ISSUES/002-implement-auth-admin.md
+++ b/.github/ISSUES/002-implement-auth-admin.md
@@ -1,0 +1,17 @@
+# Implement authentication & admin UI
+
+**Labels:** enhancement, feature, backend
+**Priority:** Medium
+
+## Summary
+Add user authentication with secure password hashing and an admin role; provide protected admin endpoints and basic UI.
+
+## Acceptance criteria
+- Add a `User` model with hashed passwords (bcrypt or Argon2).
+- Implement login/logout endpoints and session or token-based authentication.
+- Add admin-only endpoints/pages to create/edit activities and view registrations.
+- Add tests for auth flows and role checks.
+- Document how to create admin users and configure secrets.
+
+## Notes
+Avoid using weak hashing (e.g., SHA-1). Prefer a modern password hashing scheme and follow best practices for session management.

--- a/.github/ISSUES/003-add-bulk-mailer.md
+++ b/.github/ISSUES/003-add-bulk-mailer.md
@@ -1,0 +1,17 @@
+# Add bulk mailer & mailing lists (CSV import + SMTP)
+
+**Labels:** enhancement, feature, backend
+**Priority:** Medium
+
+## Summary
+Add functionality for admins to upload CSV mailing lists and send HTML bulk emails via configurable SMTP.
+
+## Acceptance criteria
+- Add upload endpoint for CSV to create/maintain mailing lists (persisted in DB).
+- Add email template rendering and preview functionality (Jinja templates).
+- Add SMTP configuration via environment variables and a safe sending flow (with rate limiting or preview mode).
+- Add unit tests for CSV import and email sending (mocking SMTP).
+- Add documentation describing usage and configuration.
+
+## Notes
+Ensure email sending is testable offline and avoid leaking SMTP credentials; use environment config.


### PR DESCRIPTION
This PR adds three issue markdown files under `.github/ISSUES/` for the top requested improvements:

- Add persistent DB for activities & registrations
- Implement authentication & admin UI
- Add bulk mailer & mailing lists (CSV import + SMTP)

These are draft issue files so you can review, adjust, and convert them to GitHub issues as desired.